### PR TITLE
First pass at Ansible role to deploy Ark

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,44 @@
+# Archivist Ansible Roles / Playbooks
+
+This directory contains playbooks and Ansible roles to deploy both Ark and OpenShift.
+
+## Requirements
+
+You will need AWS credentials with permission to create S3 buckets, write to
+S3, and create PV snapshots.
+
+Store your AWS credentials as a separate profile in ~/.aws/credentials. (suggest "ark" for this example)
+
+You will need to manually create an S3 bucket beforehand:
+
+```
+$ aws s3api create-bucket --bucket dgoodwin-ark-testing --region us-east-1 --profile ark
+```
+
+
+Create vars/zz_custom_vars.yml:
+
+```
+arko_aws_secret_access_key: ""
+arko_aws_access_key_id: ""
+arko_aws_region: us-east-1
+arko_aws_availability_zone: us-east-1d
+arko_aws_bucket: dgoodwin-ark-testing
+```
+
+The zz prefix should ensure it's always loaded last and thus overrides all
+other vars. This file should *never* be comitted to git and is added to
+.gitignore.
+
+You're now ready to deploy Ark and the Archivist, assuming you've already done
+a standard Online team devenv deploy, point this command to your inventory
+(likely generated with aws-launcher):
+
+```
+$ gogitit sync && ansible-playbook -i ~/src/online/ansible/hosts archivist.yml
+```
+
+NOTE: gogitit should be installed if you've used the devenv-launch playbook.
+
+NOTE: these playbooks and roles will be vendored in for integration into the
+standard devenv deploy.

--- a/ansible/archivist.yml
+++ b/ansible/archivist.yml
@@ -24,6 +24,10 @@
   - include_role:
       name: lib_openshift
 
+  # Deploy Ark for managing all backup/restore operations:
+  - include_role:
+      name: ark_openshift
+
   - include_role:
       name: oso_archivist
     vars:

--- a/ansible/ark.yml
+++ b/ansible/ark.yml
@@ -1,0 +1,25 @@
+---
+- name: Deploy Heptio Ark
+  hosts: masters
+  remote_user: root
+  run_once: true
+  tasks:
+
+  - set_fact:
+      vars_dir: "./vars/"
+    when: vars_dir is not defined
+
+  - name: Check if vars/ exists
+    local_action: stat path="{{ vars_dir }}"
+    register: vars_dir_stat
+    become: no
+
+  - name: Load all variables from vars/
+    include_vars:
+      dir: "{{ vars_dir }}"
+      extensions:
+      - yml
+    when: vars_dir_stat.stat.exists
+
+  - include_role:
+      name: ark_openshift

--- a/ansible/roles/ark_openshift/README.md
+++ b/ansible/roles/ark_openshift/README.md
@@ -1,0 +1,18 @@
+# ark_openshift
+
+An Ansible role to deploy [Ark](https://github.com/heptio/ark) on OpenShift for
+managing cluster backup and restore. This role currently assumes you are
+deploying to a cluster on AWS.
+
+## Dependencies
+
+## Role Variables
+
+### Required
+
+* arko_aws_secret_access_key
+* arko_aws_access_key_id
+* arko_aws_region
+* arko_aws_availability_zone
+* arko_aws_bucket - A S3 bucket for this specific cluster. (NOTE: do not have multiple clusters using the same S3 bucket) Must be created beforehand.
+

--- a/ansible/roles/ark_openshift/defaults/main.yml
+++ b/ansible/roles/ark_openshift/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+arko_yaml_dir: "/opt/ark/"

--- a/ansible/roles/ark_openshift/files/00-prereqs.yaml
+++ b/ansible/roles/ark_openshift/files/00-prereqs.yaml
@@ -1,0 +1,193 @@
+# Copyright 2017 Heptio Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backups
+    kind: Backup
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: schedules.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: schedules
+    kind: Schedule
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: restores
+    kind: Restore
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: configs.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: configs
+    kind: Config
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: downloadrequests.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: downloadrequests
+    kind: DownloadRequest
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: heptio-ark
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ark
+  namespace: heptio-ark
+  labels:
+    component: ark
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: ark
+  labels:
+    component: ark
+rules:
+  - apiGroups:
+      - "*"
+    verbs:
+      - list
+      - watch
+      - create
+    resources:
+      - "*"
+  - apiGroups:
+      - apiextensions.k8s.io
+    verbs:
+      - create
+    resources:
+      - customresourcedefinitions
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ark
+  labels:
+    component: ark
+subjects:
+  - kind: ServiceAccount
+    namespace: heptio-ark
+    name: ark
+roleRef:
+  kind: ClusterRole
+  name: ark
+  apiGroup: rbac.authorization.k8s.io
+
+# NOTE: this is a custom change to fix problems with restoring projects
+# https://github.com/heptio/ark/issues/73
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ark-cluster-admin
+  labels:
+    component: ark
+subjects:
+  - kind: ServiceAccount
+    namespace: heptio-ark
+    name: ark
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: heptio-ark
+  name: ark
+  labels:
+    component: ark
+rules:
+  - apiGroups:
+      - ark.heptio.com
+    verbs:
+      - "*"
+    resources:
+      - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  namespace: heptio-ark
+  name: ark
+  labels:
+    component: ark
+subjects:
+  - kind: ServiceAccount
+    namespace: heptio-ark
+    name: ark
+roleRef:
+  kind: Role
+  name: ark
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles/ark_openshift/files/10-deployment.yaml
+++ b/ansible/roles/ark_openshift/files/10-deployment.yaml
@@ -1,0 +1,53 @@
+# Copyright 2017 Heptio Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  namespace: heptio-ark
+  name: ark
+  labels:
+    component: ark
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: ark
+    spec:
+      restartPolicy: Always
+      serviceAccountName: ark
+      containers:
+        - name: ark
+          image: docker.io/dgoodwin/ark:latest
+          command:
+            - /ark
+          args:
+            - server
+            - --logtostderr
+            - --v
+            - "4"
+          volumeMounts:
+            - name: cloud-credentials
+              mountPath: /credentials
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+          # TODO: for development
+          imagePullPolicy: Always
+      volumes:
+        - name: cloud-credentials
+          secret:
+            secretName: cloud-credentials

--- a/ansible/roles/ark_openshift/tasks/main.yml
+++ b/ansible/roles/ark_openshift/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+- name: Check for required vars
+  fail:
+    msg: "Please specify a value for {{ item }}"
+  when: item is undefined
+  with_items:
+  - arko_aws_secret_access_key
+  - arko_aws_access_key_id
+  - arko_aws_region
+  - arko_aws_availability_zone
+  - arko_aws_bucket
+
+- include: uninstall.yml
+#  when: ark_uninstall | bool
+
+# CustomResourceDefinitions only supported as of 3.7:
+- name: Check OpenShift version
+  oc_version:
+  register: oc_version
+
+- debug: var=oc_version
+
+- fail:
+    msg: "Ark can only be deployed on OpenShift 3.7+"
+  when: oc_version.results.openshift_numeric | version_compare('3.7', '<=')
+
+- copy:
+    src: 00-prereqs.yaml
+    dest: "{{ arko_yaml_dir }}/common/"
+
+- name: create ark prereqs
+  command: "kubectl apply -f {{ arko_yaml_dir }}/common/00-prereqs.yaml"
+
+- name: create AWS credentials secret file
+  template:
+    src: aws-creds-template
+    dest: "{{ arko_yaml_dir}}/credentials-ark"
+
+- name: create AWS credentials secret
+  command: "kubectl create secret generic cloud-credentials --namespace heptio-ark --from-file cloud={{ arko_yaml_dir }}/credentials-ark"
+
+- file:
+    path: "{{ arko_yaml_dir }}/aws/"
+    state: directory
+    mode: 0700
+
+- template:
+    src: aws/00-ark-config.yaml
+    dest: "{{ arko_yaml_dir }}/aws/00-ark-config.yaml"
+
+- name: create Ark configuration
+  command: "kubectl apply -f {{ arko_yaml_dir }}/aws/00-ark-config.yaml"
+
+- copy:
+    src: 10-deployment.yaml
+    dest: "{{ arko_yaml_dir }}/common/"
+
+- name: create ark deployment
+  command: "kubectl apply -f {{ arko_yaml_dir }}/common/10-deployment.yaml"
+

--- a/ansible/roles/ark_openshift/tasks/uninstall.yml
+++ b/ansible/roles/ark_openshift/tasks/uninstall.yml
@@ -1,0 +1,9 @@
+---
+- command: oc delete project heptio-ark
+  failed_when: false
+
+- pause:
+    seconds: 30
+
+- command: "kubectl delete -f {{ arko_yaml_dir }}/common/"
+  failed_when: false

--- a/ansible/roles/ark_openshift/templates/aws-creds-template
+++ b/ansible/roles/ark_openshift/templates/aws-creds-template
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id={{ arko_aws_access_key_id }}
+aws_secret_access_key={{ arko_aws_secret_access_key }}

--- a/ansible/roles/ark_openshift/templates/aws/00-ark-config.yaml
+++ b/ansible/roles/ark_openshift/templates/aws/00-ark-config.yaml
@@ -1,0 +1,39 @@
+# Copyright 2017 Heptio Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: ark.heptio.com/v1
+kind: Config
+metadata:
+  namespace: heptio-ark
+  name: default
+persistentVolumeProvider:
+  aws:
+    region: {{ arko_aws_region }}
+    availabilityZone: {{ arko_aws_availability_zone }}
+backupStorageProvider:
+  bucket: {{ arko_aws_bucket }}
+  aws:
+    region: {{ arko_aws_region }}
+backupSyncPeriod: 30m
+gcSyncPeriod: 30m
+scheduleSyncPeriod: 1m
+restoreOnlyMode: false
+resourcePriorities:
+  - namespaces
+  - serviceaccounts
+  - persistentvolumes
+  - persistentvolumeclaims
+  - secrets
+  - configmaps

--- a/ansible/vars/archivist_vars.yml
+++ b/ansible/vars/archivist_vars.yml
@@ -1,0 +1,8 @@
+online_archivist_appname: "archivist"
+online_archivist_git_repo: "https://github.com/openshift/online-archivist.git"
+online_archivist_git_ref: "master"
+online_archivist_namespace_high_watermark: 10
+online_archivist_namespace_low_watermark: 6
+online_archivist_min_inactive_days: 1
+online_archivist_max_inactive_days: 6
+


### PR DESCRIPTION
The role is a little different from our other app roles, Ark ships raw yaml for how to deploy and create their custom resource types. (we also don't have support for creating some of these things in lib_openshift like custom resource types) I wanted to be able to diff the yaml against upstream to keep it up to date.

However deploying raw yaml (idempotently) with Ansible is a mess right now. Kubectl apply has something for this, kind of. I'm using that but we still blow away the entire app on each run so it's not really having much effect yet.

A list of improvements for future is documented in trello, but for now this gets us up and running for development.