### PR TITLE
Improve idempotency for Ansible role.

### DIFF
--- a/ansible/roles/oc_start_build_check/library/oc_start_build_check.py
+++ b/ansible/roles/oc_start_build_check/library/oc_start_build_check.py
@@ -1,0 +1,68 @@
+'''
+Module to check an OpenShift Git BuildConfig and determine if the latest build matches the requested git ref. If not, an oc start-build will be run.
+'''
+
+import subprocess
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+
+def start_build(module):
+    run_command(['oc', 'start-build', '-n', module.params['namespace'], module.params['buildconfig']])
+
+
+def main():
+    module = AnsibleModule(argument_spec=dict(
+        namespace=dict(required=True, type='str'),
+        buildconfig=dict(required=True, type='str'),
+        git_ref=dict(required=True, type='str'),
+    ))
+
+    output_lines = []
+    changed = False
+
+    bc_out = run_command(['oc', 'get', '-n', module.params['namespace'], 'BuildConfig',
+        module.params['buildconfig'], '-o', 'yaml'])
+    buildconfig = yaml.safe_load(bc_out)
+
+    # Handle buildconfig not from git source
+    if 'source' not in buildconfig['spec'] or \
+            buildconfig['spec']['source']['type'] != 'Git':
+            module.fail_json(msg="BuildConfig '%s' does not use Git source" % module.params['buildconfig'],
+                    output=output_lines)
+
+    if 'status' not in buildconfig or 'lastVersion' not in buildconfig['status']:
+        output_lines.append("No status or lastVersion on BuildConfig, starting build.")
+        changed = True
+        output_lines.append(start_build(module))
+    else:
+        expected_latest_build = "%s-%s" % (module.params['buildconfig'], buildconfig['status']['lastVersion'])
+        output_lines.append("Expected latest build: %s" % expected_latest_build)
+        build_out = run_command(['oc', 'get', '-n', module.params['namespace'], 'Build',
+            expected_latest_build, '-o', 'yaml'])
+        latest_build = yaml.safe_load(build_out)
+
+        if latest_build['status']['phase'] == 'Failed':
+            output_lines.append("Last build failed, starting another.")
+            changed = True
+            output_lines.append(start_build(module))
+        elif latest_build['status']['phase'] == 'Running':
+            output_lines.append("Build already running, skipping.")
+        else:
+            if module.params['git_ref'] != latest_build['spec']['revision']['git']['commit']:
+                output_lines.append("Git refs do not match: %s != %s" % (module.params['git_ref'],
+                    latest_build['spec']['revision']['git']['commit']))
+                changed = True
+                output_lines.append(start_build(module))
+            else:
+                output_lines.append("Git ref matches.")
+
+    module.exit_json(changed=changed, output=output_lines)
+
+def run_command(cmds):
+    output = subprocess.check_output(cmds)
+    return output
+
+if __name__ == '__main__':
+    main()
+

--- a/ansible/roles/oso_archivist/README.md
+++ b/ansible/roles/oso_archivist/README.md
@@ -14,13 +14,10 @@ This role expects to run with system:admin credentials as it creates roles with
 certain elevated privileges to manage the cluster. Typically this is
 accomplished by running as root on a master host.
 
-*WARNING*: When run, this role will always update the template and reprocess it, leading
-to recreating the build and deployment configs, and thus restarting the running
-application. *NOT FOR USE IN ONGOING CONFIG MANAGEMENT LOOPS*
-
 ## Dependencies
 
 - lib_openshift role from openshift-ansible must be loaded in a playbook prior to running this role.
+- oc_start_build_check role from this repo.
 
 ## Role Variables
 

--- a/ansible/roles/oso_archivist/tasks/main.yml
+++ b/ansible/roles/oso_archivist/tasks/main.yml
@@ -14,14 +14,13 @@
 
 - debug: msg="Deploying {{ osoa_appname}} from {{ osoa_git_repo }} ref {{osoa_git_ref }}"
 
-- name: copy archivist template
+- name: Copy template
   copy:
     src: archivist-template.yaml
     dest: "{{ osoa_template_path }}"
-    #  register: copy_template_out
 
 # This task should correctly only indicate a change if the underlying template changed.
-- name: create template
+- name: Create template
   oc_obj:
     state: present
     namespace: "{{ osoa_namespace }}"
@@ -30,17 +29,37 @@
     files:
     - "{{ osoa_template_path }}"
 
-- name: oc process template
-  oc_process:
+- name: Apply template
+  shell: "oc process -n {{ osoa_namespace }} archivist -p NAME='{{ osoa_appname }}' -p GIT_REPO='{{ osoa_git_repo }}' -p GIT_REF='{{ osoa_git_ref }}' -p NAMESPACE_HIGH_WATERMARK='{{ osoa_namespace_high_watermark }}' -p NAMESPACE_LOW_WATERMARK='{{ osoa_namespace_low_watermark }}' -p MIN_INACTIVE_DAYS='{{ osoa_min_inactive_days }}' -p MAX_INACTIVE_DAYS='{{ osoa_max_inactive_days }}' | oc apply -n {{ osoa_namespace }} -f -"
+  # apply does not indicate if something changed today. Assume changed_when
+  # false and rely on the template update as our best indicator if something
+  # changed.
+  changed_when: false
+
+- name: Fetch latest git commit
+  git:
+    repo: "{{ osoa_git_repo }}"
+    version: "{{ osoa_git_ref }}"
+    clone: no
+    accept_hostkey: true
+  register: git_sha1_results
+  # Git may not be installed on remote hosts.
+  delegate_to: localhost
+  changed_when: false
+
+- debug: msg="Checking that latest build matches git ref: {{ git_sha1_results.after }}"
+
+- name: Load the start-build role so module is available
+  include_role:
+    name: oc_start_build_check
+
+- name: Start build if required
+  oc_start_build_check:
     namespace: "{{ osoa_namespace }}"
-    template_name: archivist
-    reconcile: True
-    create: True
-    params:
-      NAME: "{{ osoa_appname }}"
-      GIT_REPO: "{{ osoa_git_repo }}"
-      GIT_REF: "{{ osoa_git_ref }}"
-      NAMESPACE_HIGH_WATERMARK: "{{ osoa_namespace_high_watermark }}"
-      NAMESPACE_LOW_WATERMARK: "{{ osoa_namespace_low_watermark }}"
-      MIN_INACTIVE_DAYS: "{{ osoa_min_inactive_days }}"
-      MAX_INACTIVE_DAYS: "{{ osoa_max_inactive_days }}"
+    buildconfig: "{{ osoa_appname }}"
+    git_ref: "{{ git_sha1_results.after }}"
+  register: start_build_out
+
+- debug: var=start_build_out
+
+


### PR DESCRIPTION
Stop fully reprocessing the template on every running, implicitly
leading to a slow re-build which may not be necessary.

Instead pipe template process output to oc apply, which maintains
previous state and will update them to match the latest requested.

Add a role with associated python module to intelligently check if a
git build is required.