### PR TITLE
Improve Ark ansible role.

### DIFF
--- a/ansible/archivist.yml
+++ b/ansible/archivist.yml
@@ -21,9 +21,6 @@
       - yml
     when: vars_dir_stat.stat.exists
 
-  - include_role:
-      name: lib_openshift
-
   # Deploy Ark for managing all backup/restore operations:
   - include_role:
       name: ark_openshift

--- a/ansible/roles/ark_openshift/defaults/main.yml
+++ b/ansible/roles/ark_openshift/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 arko_yaml_dir: "/opt/ark/"
+# WARNING: ark currently assumes you must use this namespace
+arko_namespace: "heptio-ark"
+arko_uninstall: False

--- a/ansible/roles/ark_openshift/meta/main.yml
+++ b/ansible/roles/ark_openshift/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: lib_openshift }

--- a/ansible/roles/ark_openshift/tasks/main.yml
+++ b/ansible/roles/ark_openshift/tasks/main.yml
@@ -11,33 +11,40 @@
   - arko_aws_bucket
 
 - include: uninstall.yml
-#  when: ark_uninstall | bool
+  when: arko_uninstall | bool
 
 # CustomResourceDefinitions only supported as of 3.7:
 - name: Check OpenShift version
   oc_version:
   register: oc_version
 
-- debug: var=oc_version
-
 - fail:
     msg: "Ark can only be deployed on OpenShift 3.7+"
   when: oc_version.results.openshift_numeric | version_compare('3.7', '<=')
 
-- copy:
+- name: copy ark prereqs
+  template:
     src: 00-prereqs.yaml
-    dest: "{{ arko_yaml_dir }}/common/"
+    dest: "{{ arko_yaml_dir}}/common/"
 
 - name: create ark prereqs
   command: "kubectl apply -f {{ arko_yaml_dir }}/common/00-prereqs.yaml"
+  # TODO: all kubectl apply commands here are using change_when false until kubectl can inform
+  # us when something changed or not. (hopefully 1.9)
+  changed_when: false
+
+- name: base64 encode cloud credentials
+  set_fact:
+    cloud_creds: "{{ '[default]\naws_access_key_id={{ arko_aws_access_key_id }}\naws_secret_access_key={{ arko_aws_secret_access_key }}\n' | b64encode }}"
 
 - name: create AWS credentials secret file
   template:
-    src: aws-creds-template
-    dest: "{{ arko_yaml_dir}}/credentials-ark"
+    src: cloud-credentials-secret.yaml
+    dest: "{{ arko_yaml_dir}}/cloud-credentials-secret.yaml"
 
 - name: create AWS credentials secret
-  command: "kubectl create secret generic cloud-credentials --namespace heptio-ark --from-file cloud={{ arko_yaml_dir }}/credentials-ark"
+  command: "kubectl apply --namespace {{ arko_namespace }} -f {{ arko_yaml_dir }}/cloud-credentials-secret.yaml"
+  changed_when: false
 
 - file:
     path: "{{ arko_yaml_dir }}/aws/"
@@ -50,11 +57,13 @@
 
 - name: create Ark configuration
   command: "kubectl apply -f {{ arko_yaml_dir }}/aws/00-ark-config.yaml"
+  changed_when: false
 
-- copy:
+- template:
     src: 10-deployment.yaml
     dest: "{{ arko_yaml_dir }}/common/"
 
 - name: create ark deployment
   command: "kubectl apply -f {{ arko_yaml_dir }}/common/10-deployment.yaml"
+  changed_when: false
 

--- a/ansible/roles/ark_openshift/templates/00-prereqs.yaml
+++ b/ansible/roles/ark_openshift/templates/00-prereqs.yaml
@@ -89,12 +89,6 @@ spec:
 
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: heptio-ark
-
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ark

--- a/ansible/roles/ark_openshift/templates/10-deployment.yaml
+++ b/ansible/roles/ark_openshift/templates/10-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - --log-level
             - debug
           volumeMounts:
-            - name: cloud-credentials
+            - name: ark-cloud-credentials
               mountPath: /credentials
           env:
             - name: AWS_SHARED_CREDENTIALS_FILE
@@ -49,6 +49,6 @@ spec:
           # TODO: for development
           imagePullPolicy: Always
       volumes:
-        - name: cloud-credentials
+        - name: ark-cloud-credentials
           secret:
-            secretName: cloud-credentials
+            secretName: ark-cloud-credentials

--- a/ansible/roles/ark_openshift/templates/aws-creds-template
+++ b/ansible/roles/ark_openshift/templates/aws-creds-template
@@ -1,3 +1,0 @@
-[default]
-aws_access_key_id={{ arko_aws_access_key_id }}
-aws_secret_access_key={{ arko_aws_secret_access_key }}

--- a/ansible/roles/ark_openshift/templates/cloud-credentials-secret.yaml
+++ b/ansible/roles/ark_openshift/templates/cloud-credentials-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  cloud: {{ cloud_creds }}
+kind: Secret
+metadata:
+  name: ark-cloud-credentials
+  namespace: heptio-ark
+type: Opaque

--- a/ansible/roles/oso_archivist/files/archivist-template.yaml
+++ b/ansible/roles/oso_archivist/files/archivist-template.yaml
@@ -109,7 +109,7 @@ objects:
         maxInactiveDays: ${MAX_INACTIVE_DAYS}
       protectedNamespaces:
       - default
-      - heptio-ark # TODO: remove once ark is in the openshift-infra namespace
+      - heptio-ark
       - kube-public
       - kube-system
       - logging

--- a/ansible/roles/oso_archivist/meta/main.yml
+++ b/ansible/roles/oso_archivist/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: lib_openshift }
+  - { role: oc_start_build_check }


### PR DESCRIPTION
Now idempotent, you can re-run it and we won't fully clobber the
existing Ark pods unless necessary.

Ark had to remain in heptio-ark namespace, aparently this is required.