### PR TITLE
README: remove make test-integration since there is no such rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,6 @@ Unit tests:
 $ make test
 ```
 
-Integration tests (launches an OpenShift master and etcd internally to work against):
-
-```
-$ make test-integration
-```
-
 # Deploy To an OpenShift Cluster
 
 TODO: An ansible role is in progress that should allow deploying to any


### PR DESCRIPTION
There is no such rule in the [Makefile](https://github.com/openshift/online-archivist/blob/master/Makefile).